### PR TITLE
Complete support for dynamic container names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run nginx proxy as a separate container you'll need:
 curl https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
-2) Set the `NGINX_DOCKER_GEN_CONTAINER` environment variable to the name or id of the docker-gen container.
+2) Use the `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen=true` label on the docker-gen container, or explicitly set the `NGINX_DOCKER_GEN_CONTAINER` environment variable to the name or id of that container.
 
 Examples:
 
@@ -86,23 +86,25 @@ $ docker run -d \
     --volumes-from nginx \
     -v /path/to/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen=true \
     jwilder/docker-gen \
     -notify-sighup nginx -watch -wait 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 ```
 
-* Then start this container (NGINX_DOCKER_GEN_CONTAINER variable must contain the docker-gen container name or id):
+* Then start this container:
 ```bash
 $ docker run -d \
     --name nginx-letsencrypt \
-    -e "NGINX_DOCKER_GEN_CONTAINER=nginx-gen" \
     --volumes-from nginx \
     -v /path/to/certs:/etc/nginx/certs:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
     jrcs/letsencrypt-nginx-proxy-companion
 ```
-Then start any containers to be proxied as described previously.
 
-* If for some reason you can't use the docker --volumes-from option, you can specify the name or id of the nginx container with `NGINX_PROXY_CONTAINER` variable.
+* Then start any containers to be proxied as described previously.
+
+Note: If the docker-gen container name is static and you want to explicitly set it, use `-e NGINX_DOCKER_GEN_CONTAINER=nginx-gen`. The same thing is true with the nginx container (`-e NGINX_PROXY_CONTAINER=nginx`).
+
 
 #### Let's Encrypt
 
@@ -172,5 +174,5 @@ If you want other examples how to use this container, look at:
 * [Evert Ramos's Examples](https://github.com/evertramos/docker-compose-letsencrypt-nginx-proxy-companion) - using docker-compose version '3'
 * [Karl Fathi's Examples](https://github.com/fatk/docker-letsencrypt-nginx-proxy-companion-examples)
 * [More examples from Karl](https://github.com/pixelfordinner/pixelcloud-docker-apps/tree/master/nginx-proxy)
-* [George Ilyes' Examples](https://github.com/gilyes/docker-nginx-letsencrypt-sample) 
+* [George Ilyes' Examples](https://github.com/gilyes/docker-nginx-letsencrypt-sample)
 * [Dmitry's simple docker-compose example](https://github.com/dmitrym0/simple-lets-encrypt-docker-compose-sample)

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -33,7 +33,7 @@ function get_nginx_proxy_cid {
             break
         fi
     done
-    if [[ -z "$(nginx_proxy_cid)" ]]; then
+    if [[ -z "$(nginx_proxy_container)" ]]; then
         echo "Error: can't get nginx-proxy container id !" >&2
         echo "Check that you use the --volumes-from option to mount volumes from the nginx-proxy or label the nginx proxy container to use with 'com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true'." >&2
         exit 1
@@ -74,7 +74,7 @@ source /app/functions.sh
 
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_docker_socket
-    if [[ -z "$(docker_gen_cid)" ]]; then
+    if [[ -z "$(docker_gen_container)" ]]; then
         [[ -z "${NGINX_PROXY_CONTAINER:-}" ]] && get_nginx_proxy_cid
     fi
     check_writable_directory '/etc/nginx/certs'

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -23,14 +23,6 @@ EOT
     fi
 }
 
-function get_nginx_gen_cid {
-    # Check if any container has been labelled as the nginx gen container.
-    local labeled_cid=$(docker_api "/containers/json" | jq -r '.[] | select( .Labels["com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_gen"] == "true")|.Id')
-    if [[ ! -z "${labeled_cid:-}" ]]; then
-        export NGINX_DOCKER_GEN_CONTAINER=$labeled_cid
-    fi
-}
-
 function get_nginx_proxy_cid {
     # Look for a NGINX_VERSION environment variable in containers that we have mount volumes from.
     local volumes_from=$(docker_api "/containers/$CONTAINER_ID/json" | jq -r '.HostConfig.VolumesFrom[]' 2>/dev/null)
@@ -41,12 +33,7 @@ function get_nginx_proxy_cid {
             break
         fi
     done
-    # Check if any container has been labelled as the nginx proxy container.
-    local labeled_cid=$(docker_api "/containers/json" | jq -r '.[] | select( .Labels["com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"] == "true")|.Id')
-    if [[ ! -z "${labeled_cid:-}" ]]; then
-        export NGINX_PROXY_CONTAINER=$labeled_cid
-    fi
-    if [[ -z "${NGINX_PROXY_CONTAINER:-}" ]]; then
+    if [[ -z "$(nginx_proxy_cid)" ]]; then
         echo "Error: can't get nginx-proxy container id !" >&2
         echo "Check that you use the --volumes-from option to mount volumes from the nginx-proxy or label the nginx proxy container to use with 'com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true'." >&2
         exit 1
@@ -87,8 +74,7 @@ source /app/functions.sh
 
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_docker_socket
-    [[ -z "${NGINX_DOCKER_GEN_CONTAINER:-}" ]] && get_nginx_gen_cid
-    if [[ -z "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
+    if [[ -z "$(docker_gen_cid)" ]]; then
         [[ -z "${NGINX_PROXY_CONTAINER:-}" ]] && get_nginx_proxy_cid
     fi
     check_writable_directory '/etc/nginx/certs'

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -72,11 +72,11 @@ function labeled_cid {
 }
 
 function docker_gen_container {
-    echo ${NGINX_DOCKER_GEN_CONTAINER:-labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen}
+    echo ${NGINX_DOCKER_GEN_CONTAINER:-$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen)}
 }
 
 function nginx_proxy_container {
-    echo ${NGINX_PROXY_CONTAINER:-labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy}
+    echo ${NGINX_PROXY_CONTAINER:-$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy)}
 }
 
 ## Nginx

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -67,21 +67,37 @@ function docker_kill {
     docker_api "/containers/$id/kill?signal=$signal" "POST"
 }
 
+function labeled_cid {
+    docker_api "/containers/json" | jq -r '.[] | select( .Labels["'$1'"] == "true")|.Id'
+}
+
+function docker_gen_container {
+    echo ${NGINX_DOCKER_GEN_CONTAINER:-labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen}
+}
+
+function nginx_proxy_container {
+    echo ${NGINX_PROXY_CONTAINER:-labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy}
+}
+
 ## Nginx
 reload_nginx() {
-    if [[ -n "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
+    local _docker_gen_container=$(docker_gen_container)
+    local _nginx_proxy_container=$(nginx_proxy_container)
+
+    if [[ -n "${_docker_gen_container:-}" ]]; then
         # Using docker-gen and nginx in separate container
-        echo "Reloading nginx docker-gen (using separate container ${NGINX_DOCKER_GEN_CONTAINER})..."
-        docker_kill "$NGINX_DOCKER_GEN_CONTAINER" SIGHUP
-        if [[ -n "${NGINX_PROXY_CONTAINER:-}" ]]; then
+        echo "Reloading nginx docker-gen (using separate container ${_docker_gen_container})..."
+        docker_kill "${_docker_gen_container}" SIGHUP
+
+        if [[ -n "${_nginx_proxy_container:-}" ]]; then
             # Reloading nginx in case only certificates had been renewed
-            echo "Reloading nginx (using separate container ${NGINX_PROXY_CONTAINER})..."
-            docker_kill "$NGINX_PROXY_CONTAINER" SIGHUP
+            echo "Reloading nginx (using separate container ${_nginx_proxy_container})..."
+            docker_kill "${_nginx_proxy_container}" SIGHUP
         fi
     else
-        if [[ -n "${NGINX_PROXY_CONTAINER:-}" ]]; then
-            echo "Reloading nginx proxy..."
-            docker_exec "$NGINX_PROXY_CONTAINER" \
+        if [[ -n "${_nginx_proxy_container:-}" ]]; then
+            echo "Reloading nginx proxy (${_nginx_proxy_container})..."
+            docker_exec "${_nginx_proxy_container}" \
                         '[ "sh", "-c", "/usr/local/bin/docker-gen -only-exposed /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload" ]'
         fi
     fi


### PR DESCRIPTION
This is my attempt to solve the same #205 issue.

In Swarm Mode and Docker Cloud, container names are dynamic. #181 solved this partially with a label on `jwilder/nginx-proxy` but not if they're separate containers. #126 tries a different approach, but I think using a label is a better one.

This PR simply adds a `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen=true` label to the docker-gen container.

It also moves the label related detection to runtime (functions.sh: nginx-reload) instead of startup time (entrypoint.sh), because the nginx and docker-gen containers could be redeployed during the lifecycle of the letsencrypt companion, and thus, getting different ids.

There's also a new assumption in that I think it's simpler to just recommend using the label instead of `volumes-from` to detect the nginx-proxy container. The reason is that in some environments (like mine), you can't use `volumes-from`, but I think you can always use labels.

Note: If you're wandering why I've chosen not to set the variables `NGINX_DOCKER_GEN_CONTAINER` and `NGINX_PROXY_CONTAINER`, that's because we can use them to make sure an explicitly set container name takes precedence over a label.

Now I'm running a successful separate containers deployment in Swarm Mode, here's my stack:
```
version: '3.2'
services:
  nginx:
    image: nginx:alpine
    ports:
      - 80:80
      - 443:443
    volumes:
      - ./nginx/conf.d:/etc/nginx/conf.d
      - ./nginx/vhost.d:/etc/nginx/vhost.d
      - ./nginx/certs:/etc/nginx/certs
      - ./nginx/letsencrypt:/usr/share/nginx/html
    labels:
      - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true
    deploy:
      placement:
        constraints:
          - node.role == manager

  dockergen:
    image: helder/docker-gen
    command: -notify "docker-label-sighup com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy" -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
      - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl
      - ./nginx/conf.d:/etc/nginx/conf.d
      - ./nginx/vhost.d:/etc/nginx/vhost.d
      - ./nginx/certs:/etc/nginx/certs
    labels:
      - com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen=true
    deploy:
      placement:
        constraints:
          - node.role == manager

  letsencrypt:
    image: helder/letsencrypt-nginx-proxy-companion:latest
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
      - ./nginx/conf.d:/etc/nginx/conf.d
      - ./nginx/vhost.d:/etc/nginx/vhost.d
      - ./nginx/certs:/etc/nginx/certs
      - ./nginx/letsencrypt:/usr/share/nginx/html
    deploy:
      placement:
        constraints:
          - node.role == manager
```

As you can see, I'm also using a custom `helder/docker-gen` image which simply adds a `docker-label-sighup` script that allows me to reload the nginx container from a label, because... well, dynamic names. `jwilder/docker-gen` doesn't support reloading containers with dynamic names (yet).